### PR TITLE
Add documentation on using Github Actions for CI/CD

### DIFF
--- a/deploy/cicd.rst
+++ b/deploy/cicd.rst
@@ -1,0 +1,52 @@
+Continuous Integration/Deployment
+=================================
+
+Your first choice for CI/CD should be Github Actions. If you are having trouble getting this to work, please ask in #engineering.
+
+.. sidebar:: Heroku Deploys
+
+   If your application is being deployed to Heroku, you should just be using Heroku Pipelines, not Github Actions.
+
+This guide will provide an overview of how the deployment process should generally work, with specific examples for the more common cases.
+
+Overview
+--------
+
+Most applications will have specific needs that may differ from other applications, but the general process for testing and deployment should follow the form:
+
+1. Run tests when pushing commits.
+2. Deploy staging build when merging PR onto master branch.
+3. Deploy production build when a release is created.
+
+The act of creating a release in Github is how you decide when to deploy a new production instance. The most recent release should always be the code that's running in production.
+
+Testing
+-------
+
+The testing action will likely vary from project to project, so your best bet will be to look at examples of what other projects have done and ask in #engineering if you are having trouble. As a general rule your testing action should run on every push. This can be accomplished by setting::
+
+  on: push
+
+in your ``.github/workflows/test.yml`` file.
+
+Fargate Deployment
+------------------
+
+Most of our AWS deployments target Fargate. The staging and production deploys should look more or less the same. There is a yaml template (:download:`deploy.yml`) that can be used for both, with only a few changes you will need to make. To use this template, do the following:
+
+1. Make two copies of the template, one called ``.github/workflows/stage.yml`` and one called ``.github/workflows/prod.yml``.
+2. Set the top level ``name`` key in each file to something more descriptive, like "Deploy staging build" and "Deploy production release".
+3. For the ``stage.yml`` file change the ``on`` key to::
+
+     on:
+       push:
+         branches: [master]
+
+  And for the ``prod.yml`` file change the ``on`` key to::
+
+    on:
+      release:
+        types: [published]
+
+4. In the template, under the ``env`` section, set the ``IMAGE``, ``CLUSTER`` and ``SERVICE`` to the values given to you by the infrastructure team.
+5. You will need a set of keys for a deploy user that has permission to upload images to ECR and redeploy the ECS service (ask in #engineering if you have not been given these). These should be set as secrets through the Github UI for the repo.

--- a/deploy/cicd.rst
+++ b/deploy/cicd.rst
@@ -1,7 +1,7 @@
 Continuous Integration/Deployment
 =================================
 
-Your first choice for CI/CD should be Github Actions. If you are having trouble getting this to work, please ask in #engineering.
+Your first choice for CI/CD should be Github Actions. If you are having trouble getting this to work, please ask in the #engineering Slack channel.
 
 .. sidebar:: Heroku Deploys
 

--- a/deploy/deploy.yml
+++ b/deploy/deploy.yml
@@ -1,0 +1,44 @@
+name: Deploy
+on:
+env:
+  IMAGE:
+  CLUSTER:
+  SERVICE:
+jobs:
+  deploy:
+    name: Deploy new release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set git ref
+        id: git_ref
+        run: echo ::set-output name=ref::${GITHUB_REF/refs\/tags\//}
+
+      - name: Set AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Login to ECR
+        id: ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build container
+        env:
+          REGISTRY: ${{ steps.ecr.outputs.registry }}
+        run: docker build -t $REGISTRY/$IMAGE:latest -t $REGISTRY/$IMAGE:${{ github.sha }} .
+
+      - name: Add release tag
+        env:
+          REGISTRY: ${{ steps.ecr.outputs.registry }}
+        if: github.event_name == 'release'
+        run: docker tag $REGISTRY/$IMAGE:latest $REGISTRY/$IMAGE:${{ steps.git_ref.outputs.ref }}
+
+      - name: Publish container
+        run: docker push ${{ steps.ecr.outputs.registry }}/$IMAGE
+
+      - name: Redeploy app
+        run: aws ecs update-service --force-new-deploy --cluster $CLUSTER --service $SERVICE


### PR DESCRIPTION
Our recommended practice for CI/CD will be to use Github Actions. This
provides documentation and templates for setting up the typical Fargate
deployment that more and more of our AWS deployments are using. Heroku
apps will still be deployed using Pipelines. Any non-Fargate AWS apps
will need custom Actions set up.