### PR TITLE
Update details about deploying Rails apps on Heroku

### DIFF
--- a/deploy/heroku.md
+++ b/deploy/heroku.md
@@ -113,9 +113,13 @@ normally a quick blip and doesn’t require downtime announcements.
 ### Tag a release in GitHub with release notes that are useful
 
 From the repo code page on GitHub, go to Releases, and then click the
-"Draft a new release" button. Number the release appropriately, and
-use the number for the title if you don't have a title. Put notes on
-what's changed in the release in the description.
+"Draft a new release" button. Number the release appropriately, using [semantic
+versioniong](https://semver.org/), and title it with the release number and a
+brief overview of the changes, e.g.:
+
+`v1.5.12 Add advanced search to homepage and update dependencies`
+
+In the description, add specifics on what's changed in the release.
 
 FYI: The tag is purely informational. It is not currently used to push
 to production using Pipelines. Pushing to prod moves whatever is on
@@ -124,9 +128,9 @@ things (note: don't do weird things).
 
 ### Confirm everything is all good on staging
 
-Staging probably has `master`. If it works, pushing to prod should
-be :rainbow: unless you forgot you'll need changes to ENV for any new
-features you may be pushing if so, make said changes!
+Staging probably has the `master` branch from GitHub. If the staging app works,
+pushing to prod should be :rainbow: unless you forgot you'll need changes to
+ENV for any new features you may be pushing if so, make said changes!
 
 Get stakeholder sign off on the Pipeline staging app if it seems
 appropriate (i.e. only push stuff that has been approved to go live
@@ -155,6 +159,9 @@ to roll that back separately.
 ### Inform stakeholders if appropriate
 
 You just made a change to production. Tell people that care.
+
+NOTE: all Bento deploys trigger a notification in the #disco_ui_project Slack
+channel, so it's a good idea to provide context there whenever you deploy Bento.
 
 ## Manual Deploys
 
@@ -193,7 +200,7 @@ deployed to staging / production is best).
 ## Dynos
 
 We use paid [Dynos](https://devcenter.heroku.com/articles/dynos).
-So far the $7 plan works fine for us in production and free dynos on
+So far the \$7 plan works fine for us in production and free dynos on
 staging and pr builds. For high use apps, or apps that need more detailed metrics, use a higher tier dyno.
 
 If an app needs background jobs (email send, sword deposit, etc),

--- a/languages/rails.md
+++ b/languages/rails.md
@@ -8,8 +8,8 @@
 
 ## Test Frameworks
 
-- use of either [minitest](https://github.com/seattlerb/minitest) or
-  [rspec](https://github.com/rspec/rspec-rails) is fine
+- We recommend [minitest](https://github.com/seattlerb/minitest), as it
+  generally runs faster than rspec
 
 ## Continuous Integration
 
@@ -21,23 +21,23 @@ solution.
 To use our standard setup, do the following:
 
 - Make a copy of
-[our template](https://raw.githubusercontent.com/MITLibraries/bento/master/.github/workflows/ci.yml), 
-to your repo in the path `.github/workflows/ci.yml`. Update the last line of
-this file to match your repo at `path-to-lcov`.
+  [our template](https://raw.githubusercontent.com/MITLibraries/bento/master/.github/workflows/ci.yml),
+  to your repo in the path `.github/workflows/ci.yml`. Update the last line of
+  this file to match your repo at `path-to-lcov`.
 
 - Ensure you are using SimpleCov and have setup LCOV as a formatter.
 
   - Add `gem simplecov` and `gem simplecov-lcov` to your test group in your
-`Gemfile`:
+    `Gemfile`:
 
 ```ruby
 gem 'simplecov', require: false
 gem 'simplecov-lcov', require: false
 ```
 
-  - `bundle install`
+- `bundle install`
 
-  - Add the following to the very top of your `test/test_helper.rb`
+- Add the following to the very top of your `test/test_helper.rb`
 
 ```ruby
 require 'simplecov'
@@ -53,25 +53,22 @@ SimpleCov.start('rails')
 - Commit on a new branch and push your changes
 
 - Open a PR and your Action should run (and pass!). If not, debug or ask on our
-Slack for tips.
+  Slack for tips.
 
 ## Rails Development Environment
 
-- We maintain a [VagrantFile](https://github.com/MITLibraries/mit_vagrant_dev)
-  to help developers join our Rails projects with minimal effort
-- It is not a requirement to use it, but if you are having (or causing)
-  problems and aren't using it, please use it and see if it helps
+- For local development, you will need the ENV for the app you're working with.
+  Contact an engineer who's worked on the app, and they will provide you with
+  the requisite .env file
 
 ## Deployments
 
-- We often target [Heroku](/deploy/heroku) as a deployment platform and use Pipelines so custom
+- We target [Heroku](/deploy/heroku) as a deployment platform and use Pipelines so custom
   deployment scripts are not necessary
-- If the project requires deploying to a vm, use
-  [capistrano](https://github.com/capistrano/capistrano) or
-  [ansible](https://www.ansible.com) deployment scripts.
 
 ## Ruby Versions
 
+- We use [rbenv](https://github.com/rbenv/rbenv) to manage Ruby versions
 - Use the latest stable release unless you have a documented reason not to
   (an [ADR](https://github.com/npryce/adr-tools) would be a great place to
   document this if the project is using them)


### PR DESCRIPTION
This includes a few changes to the Heroku and Rails sections of our dev docs:

- Adds some notes to the Heroku deployment steps
- Removes the documentation in the Rails section about deploying to a VM via capistrano/ansible
- Modifies the 'Test Frameworks' part of the Rails section to explicitly recommend minitest over rspec
- Mentions that we use `rbenv` for Ruby version management
- Reminds engineers to get the .env file for local development
- Adds some weird autoformatting that my text editor did on save, which I can remove if desired

I think everything else in these two sections is mostly up to date, but it might be worth a look. One thing I was curious about is the Vagrantfile we maintain as a Rails/Python development environment. Is that still something we use for Rails development?