### PR TITLE
Fix link and DLE reference

### DIFF
--- a/misc/exception_monitoring.md
+++ b/misc/exception_monitoring.md
@@ -12,7 +12,7 @@ In general, all of the deployed custom software we write should have exception m
 
 ## How do I get an account?
 
-The accounts are maintained by DLE, so ask in our channel on Slack if don't yet have a Sentry login to our account.
+The accounts are maintained by EngX, so ask in our channel on the #engineering Slack channel if don't yet have a Sentry login to our account.
 
 ## How can I add Sentry to my application
 

--- a/misc/logging.md
+++ b/misc/logging.md
@@ -1,6 +1,6 @@
 # Central Logging
 
-We use Logz.io for central logging. All apps should be sending logs here. Note that this is different than [exception monitoring](https://mitlibraries.github.io/exception_monitoring.html).
+We use Logz.io for central logging. All apps should be sending logs here. Note that this is different than [exception monitoring](https://mitlibraries.github.io/guides/misc/exception_monitoring.html).
 
 ## Logging Standards
 


### PR DESCRIPTION
**Why**: Found a broken link and a stale reference to "DLE"

**What**: I fixed the broken link on the Logging page that points to the Exception Monitoring. While on the Exception Monitoring page, I replaced "DLE" with "EngX" and named the "#engineering" Slack channel explicitly (like we did a few weeks ago on the Logging page).

