### PR TITLE
Update recommended repo settings

### DIFF
--- a/basics/github.md
+++ b/basics/github.md
@@ -8,10 +8,8 @@ In the admin settings for repos on GitHub, the recommended settings are:
 * Edit the protected branch and check these option settings: 
     - protect this branch
     - require pull request reviews before merging
-    - dismiss stale pull request approvals when new commits are pushed
     - require status checks to pass before merging
     - require that branches are up to date
-    - include administrators
 * Allow merge commits (`Options > Merge button`)
 
 ## Workflows


### PR DESCRIPTION
This removes two recommended branch settings:

- dismiss stale pull request approvals when new commits are pushed
- include administrators

This changes reflect our current practices in EngX and InfraEng repos. While code review is required, there are edge cases in which a PR must be merged prior to review. Similarly, dismissing stale approvals should be at the PR author's discretion, as some changes (e.g., rebases) do not require a follow-up review.