### PR TITLE
Adds information about screen readers and WebAIM

### DIFF
--- a/basics/a11y.md
+++ b/basics/a11y.md
@@ -51,6 +51,12 @@
 - The [Accessible Name & Description Inspector (ANDI)
   tool](https://www.ssa.gov/accessibility/andi/help/install.html) is a
   Javascript tool to evaluate a loaded webpage.
+- A screenreader like [VoiceOver](https://www.apple.com/voiceover/info/guide/_1121.html)
+  for the Mac or [NVDA](https://www.nvaccess.org/download/) for Windows can be
+  useful for user testing to confirm that elements are reachable, or that
+  interactions will play out as expected. Articles like ["Testing with Screen
+  Readers" at WebAIM](https://webaim.org/articles/screenreader_testing/) are
+  also useful.
 
 ## Resources
 
@@ -59,3 +65,4 @@
 - [AccessLint](https://www.accesslint.com)
 - Chrome Dev Tools Accessibility Audit
 - [Google Developers Web Fundamentals: Accessibility](https://developers.google.com/web/fundamentals/accessibility/)
+- [Web Accessibility in Mind (WebAIM)](https://webaim.org/)


### PR DESCRIPTION
It occurred to me that our existing recommendations for manual a11y testing include two visual options (WAVE and ANDI) but nothing for screen readers. This adds screen readers to the list, including links to Mac and Windows tools and an article on the practice overall.