### PR TITLE
Update instructions to change default branch

### DIFF
--- a/basics/github.md
+++ b/basics/github.md
@@ -85,39 +85,15 @@ in your PR, it might be because you opened the PR prior to configuring Code Clim
 ## Updating the default branch in GitHub
 
 While all new repos will be created with `main` as the default branch, older 
-repos may still use `master` and should be migrated. Here's a quick overview of 
-how to do that:
+repos may still use `master` and should be migrated. GitHub now provides an
+easy way to do this in the web UI. In the repo's settings, you can
+change the name of the default branch.
 
-1. Check out the current default branch and ensure it’s up to date: 
-    * `git pull`
-    * `git checkout master`
-2. Rename the branch locally: `git branch -m master main`
-3. Push your branch: `git push -u origin main`
-4. Update the default branch in the remote GitHub repo from `master` to `main` 
-(Settings > Branches)
-5. Edit the protection rules for the default branch to point to `main` instead 
-of `master` (Settings > Branches)
-6. Delete `master` from the remote repo: `git push origin --delete master`
-7. Update hosting platform as needed. If you’re using Heroku and have automatic 
-deploys configured, it should update automatically
-8. Update the default branch in Code Climate (`https://codeclimate.com/github/MITLibraries/repo-name` -> Repo Settings -> General)
-9. Open a PR to update GitHub Actions CI to watch `main` instead of `master` 
-(typically this file is located in .github/workflows/ci.yml)
-10. Ask your collaborators to update their cloned repos:
-    * `git pull`
-    * `git checkout main`
-    * `git branch -d master`
+Once you change the branch name, you and your collaborators will need to pull
+the changes to your cloned repos.
 
-_Notes:
-* Normally, GitHub releases show the number of commits since the last release, 
-but changing the default branch will lose this info. A possible solution is to 
-migrate the default branch right after a release, but we have not tested this 
-yet.
-* Coveralls won't run on the initial PR to change GitHub Actions, but it should 
-switch over once that PR lands. You can verify this by looking at the repo in 
-Coveralls (`https://coveralls.io/github/MITLibraries/repo-name`) and checking 
-that it's monitoring `main` and not `master`.
-_
+Additionally, you should check any automations you have configured to ensure
+they are watching the new branch (e.g., CodeClimate, CI/CD).
 
 - - -
 


### PR DESCRIPTION
#### Why these changes are being introduced:

When we wrote these docs, GitHub did not provide a way to change
the default branch, but you can how rename the branch easily in
the web UI.

#### Relevant ticket(s):

N/A.

#### How this addresses that need:

This updates the corresponding documentation to reference the
easier method.

#### Side effects of this change:

I'm making some assumptions that Coveralls and commit history in
releases will work using GitHub's method. (Previously, the
number of commits prior to the branch change would be lost, and
Coveralls wouldn't work for the first PR.) I haven't confirmed this,
but it seems unlikely that it will be a concern for many more of our
repos at this point.