### PR TITLE
Update workflows to target the correct branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,12 +2,12 @@ name: Github Pages build
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@main
       - uses: actions/setup-python@v1
         with:
           python-version: "3.7"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,13 +2,13 @@ name: Test docs build
 on:
   push:
     branches-ignore:
-      - 'master'
+      - 'main'
       - 'gh-pages'
 jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@main
       - uses: actions/setup-python@v1
         with:
           python-version: '3.7'

--- a/languages/rails.md
+++ b/languages/rails.md
@@ -21,7 +21,7 @@ solution.
 To use our standard setup, do the following:
 
 - Make a copy of
-  [our template](https://raw.githubusercontent.com/MITLibraries/bento/master/.github/workflows/ci.yml),
+  [our template](https://raw.githubusercontent.com/MITLibraries/bento/main/.github/workflows/ci.yml),
   to your repo in the path `.github/workflows/ci.yml`. Update the last line of
   this file to match your repo at `path-to-lcov`.
 

--- a/languages/vuejs.md
+++ b/languages/vuejs.md
@@ -18,7 +18,7 @@ solution.
 To use our standard setup, do the following:
 
 - Make a copy of
-  [our template](https://github.com/MITLibraries/disco-poc-vue/blob/master/.github/workflows/ci.yml),
+  [our template](https://github.com/MITLibraries/disco-poc-vue/blob/main/.github/workflows/ci.yml),
   to your repo in the path `.github/workflows/ci.yml`.
 
 - Commit on a new branch and push your changes


### PR DESCRIPTION
#### Why these changes are being introduced:

The deploy and test workflows target `master`, which is no longer
the default branch.

#### Relevant ticket(s):

N/A.

#### How this addresses that need:

This updates workflows to target `main`.

#### Side effects of this change:

Updates links in the `rails` and `vuejs` language docs that go to
nonexistent `master` branches.