### PR TITLE
Infrastructure Related Updates

### DIFF
--- a/basics/github.md
+++ b/basics/github.md
@@ -1,17 +1,28 @@
-# GitHub 
+# GitHub
+
+## Repo naming
+
+Naming is important (see [There's Power in Naming ...](https://www.taketheleadwomen.com/blog/theres-power-in-naming-and-power-in-knowing-your-name)). More specific to our work, there are a few guidelines for naming new repos
+
+* All Terraform repo names start with **mitlib-tf** (to emphasize that these are MIT Libraries Terraform repositories)
+* All repos that are local tweaks to generally available, pre-built Docker images should start with **docker-** (to indicate that this is a Docker image, not a MIT Libraries built/managed application)
+
+There are probably more guidelines (e.g., some repo names should be recursive acronyms), but two is a good number to begin with.
 
 ## Recommended repo settings
 
-In the admin settings for repos on GitHub, the recommended settings are: 
+**Note**: Terraform repos should only be created via the [mitlib-tfc-mgmt](https://github.com/mitlibraries/mitlib-tfc-mgmt) repository (and this will take care of all of the appropriate admin settings as well as the integration with Terraform Cloud).
+
+In the admin settings for repos on GitHub, the recommended settings are:
+
 * Default branch should be "main" (`Branches > Default branch`)
 * Disable force push to the main branch. For everyone. Even admins. (`Branches > Protected branches`)
 * Edit the protected branch and check these option settings: 
-    - protect this branch
-    - require pull request reviews before merging
-    - require status checks to pass before merging
-    - require that branches are up to date
+  * protect this branch
+  * require pull request reviews before merging
+  * require status checks to pass before merging
+  * require that branches are up to date
 * Allow merge commits (`Options > Merge button`)
-* **Required for Terraform repos** Disable squash commits (`Options > Merge button`)
 
 ## Workflows
 

--- a/basics/github_desktop.md
+++ b/basics/github_desktop.md
@@ -2,17 +2,13 @@
 
 A simple, yet powerful UI based tool for both git and GitHub that may be useful for all or part of your workflow.
 
-If you already have a git tool you like, or prefer command line tools, this may not be ideal for you. However,
-it is a great starting point if you are looking for a tool to allow you to easily get started with our GitHub Flow
-workflow.
+If you already have a git tool you like, or prefer command line tools, this may not be ideal for you. However, it is a great starting point if you are looking for a tool to allow you to easily get started with our GitHub Flow workflow.
 
-The [online documentation](https://docs.github.com/en/desktop) is more likely to remain up to date than anything we create here, so we'll just cover the
-basics of the sections likely to be most of use here.
+The [online documentation](https://docs.github.com/en/desktop) is more likely to remain up to date than anything we create here, so we'll just cover the basics of the sections likely to be most of use here.
 
 ## Cloning
 
-The process of making a copy of a repository from GitHub (or any git source, but we'll focus on GitHub for the
-remainder of this document) to your local computer is called cloning.
+The process of making a copy of a repository from GitHub (or any git source, but we'll focus on GitHub for the remainder of this document) to your local computer is called cloning.
 
 Cloning a repository is the first step in making local changes to files in a repository.
 
@@ -26,8 +22,7 @@ Before you make a branch, you'll always want to synchronize changes from GitHub 
 
 ## Creating a branch
 
-[Branching](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/making-changes-in-a-branch) is a core concept in git.
-Before you start making changes, you'll want to create a branch.
+[Branching](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/making-changes-in-a-branch) is a core concept in git. Before you start making changes, you'll want to create a branch.
 
 You'll make any changes you'd like to introduce to the repository in a branch. This may include
 adding, deleting, and editing files.
@@ -44,7 +39,7 @@ Edit and save files like you would normally do (in a text editor for code/text f
 
 ## Commits
 
-Commits are a way to group a set of proposed changes. Contrary to the name, you are not _yet_ committing to the changes so don't worry if it's perfect!
+Commits are a way to group a set of proposed changes. Contrary to the name, you are not _yet_ committing to the changes so don't worry if it's not perfect!
 
 [Committing and Reviewing changes](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/making-changes-in-a-branch/committing-and-reviewing-changes-to-your-project)
 

--- a/deploy/aws-2.0.md
+++ b/deploy/aws-2.0.md
@@ -6,7 +6,7 @@ As of December 2021, MIT Libraries has shifted to an AWS Organization containing
 
 Verify that you can access our AWS Organization by visiting [MIT Libraries AWS Landing Page](https://mitlib.awsapps.com/start#/). Log in with your MIT kerb and be prepared for Touchstone MFA via the Duo app. This is the only way to access any resources in our AWS Accounts as a human. If you have any access issues, contact the InfraEng team via Slack or JSM.
 
-## AWS Organization
+## AWS Org Accounts
 
 There are multiple AWS Accounts in our single AWS Organization. A few of these accounts have very limited access for a subset of InfraEng for the purpose of audit logging and security reviews. The remainder of the accounts serve one of three purposes.
 

--- a/deploy/cicd.rst
+++ b/deploy/cicd.rst
@@ -33,8 +33,19 @@ The testing action will likely vary from project to project, so your best bet wi
 
 in your ``.github/workflows/test.yml`` file.
 
-Fargate Deployment
-------------------
+AWS 2.0 Fargate/Lambda Deployment
+---------------------------------
+
+With the migration to our AWS Organization (see `AWS 2.0 <./aws-2.0>`), we have simplified and automated the container deployment process.
+
+1. For both Lambda functions and ECS tasks/services, we make use of the AWS ECR container repositories. These are fully managed by the `mitlib-tf-workloads-ecr <https://github.com/mitlibraries/mitlib-tf-workloads-ecr>`` repository. The repo not only creates the ECR repository, it also generates the Makefile for the associated repo that builds the container as well as the GitHub Actions workflows for pushing containers to dev, stage, and prod AWS Accounts.
+2. Once an Infra engineer has deployed the ECR repository, some copy/paste from the Terraform outputs will setup the Makefile and GitHub Actions workflows for the container repo.
+3. The automation follows our standard practice that (a) PRs to the `main` branch will push an updated container to the dev AWS Account, (b) merges to `main` will push an updated container to the stage AWS Account, and (c) a tagged release on `main` will copy the container from the stage to the prod AWS Account.
+
+The section below is only necessary for applications that are not yet migrated to the new AWS Organization.
+
+Legacy AWS Fargate Deployment
+-----------------------------
 
 Most of our AWS deployments target Fargate. The staging and production deploys should look more or less the same. There is a yaml template (:download:`deploy.yml`) that can be used for both, with only a few changes you will need to make. To use this template, do the following:
 

--- a/deploy/legacy-aws.rst
+++ b/deploy/legacy-aws.rst
@@ -1,7 +1,7 @@
-Working with AWS
-================
+Legacy AWS
+==========
 
-This covers basic documentation for working with our AWS account.
+This covers basic documentation for working with our legacy AWS account.
 
 .. warning:: You will have access to create AWS resources, but you should not do this unless you have been instructed to do so. Most of our infrastructure provisioning is automated through Terraform.
 

--- a/deploy/legacy-terraform.rst
+++ b/deploy/legacy-terraform.rst
@@ -1,4 +1,4 @@
-Terraform
+Legacy Terraform
 =========
 
 This contains most of the documentation for how we use Terraform here. The primary repository is located at https://github.com/MITLibraries/mitlib-terraform but there are other repos in the org that provide modules.


### PR DESCRIPTION
Why these changes are being introduced:
1. To capture the GitHub repository naming guidelines.
2. To update the new AWS Org CI/CD process for Lambda functions and ECS tasks/services

How this addresses that need:
* Fix names for the legacy AWS page and the legacy Terraform page
* Create GitHub repo naming guidelines
* Update the CI/CD instructions for Lambda functions and Fargate containers in the new AWS Organization
* Minor tweaks to Markdown syntax in the GitHub documentation

Side effects of this change:
None.